### PR TITLE
Support 'PAUSE' xisu checkin separately 

### DIFF
--- a/include/config.example.py
+++ b/include/config.example.py
@@ -31,7 +31,7 @@ TG_BOT_PROXY = None # example: {'proxy_url': 'socks5h://127.0.0.1:1080/'}
 TG_BOT_TOKEN = ""   # Bot Token
 TG_BOT_MASTER = 0   # Master Telegram User ID
 
-CHECKIN_PROXY = None # example: {'http': 'socks5://user:pass@host:port', 'https': 'socks5://user:pass@host:port'}
+CHECKIN_PROXY = {} # example: {'http': 'socks5://user:pass@host:port', 'https': 'socks5://user:pass@host:port'}
 
 BOT_DEBUG = False
 

--- a/migrations/migration_20201023_support_pause_xisu_checkin.py
+++ b/migrations/migration_20201023_support_pause_xisu_checkin.py
@@ -1,0 +1,43 @@
+from include import *
+from peewee import SqliteDatabase
+from playhouse.migrate import *
+from migrations.MigrationBase import AbstractMigration
+
+import os
+
+'''
+Intended for server started before xisu_checkin was added
+
+'''
+
+
+class AddXisuCheckinAbstractMigration(AbstractMigration):
+    def migrate(self):
+        with self._database.atomic():
+            migrate(
+                self._migrator.add_column(
+                    table='buptuser',
+                    column_name='xisu_checkin_status',
+                    field=BUPTUser.xisu_checkin_status
+                ),
+            )
+            print(f'{__file__} migrated')
+
+    def rollback(self):
+        with self._database.atomic():
+            migrate(
+                self._migrator.drop_column(table='buptuser', column_name='xisu_checkin_status'),
+            )
+            print(f'{__file__} rolled back')
+
+
+if __name__ == '__main__':
+    os.chdir(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
+
+    database = SqliteDatabase(SQLITE_DB_FILE_PATH)
+    migrator = SqliteMigrator(database)
+
+    migration = AddXisuCheckinAbstractMigration(database=database, migrator=migrator)
+
+    migration.migrate()
+    # migration.rollback()


### PR DESCRIPTION
# Major features

Telegram bot command `/pausexisu` for normal user to pause 'xisu checkin'.

Accordingly, `/resumexisu` to resume.

# Migration steps

1. Register `/pausexisu` and `/resumexisu` command at https://t.me/BotFather
2. Make a database backup
3. Upgrade include/config.py
4. See migrations/README.md then migrate database schema `migration_20201023_support_pause_xisu_checkin`
5. Restart the service  

Slight changes to field `HELP_MARKDOWN`, please adapt to your situation.