### PR TITLE
允许用户设置当前的显示时区

### DIFF
--- a/include/config.example.py
+++ b/include/config.example.py
@@ -35,6 +35,8 @@ CHECKIN_PROXY = {} # example: {'http': 'socks5://user:pass@host:port', 'https': 
 
 BOT_DEBUG = False
 
+DISPLAY_TIMEZONE = 'Asia/Shanghai'
+
 HELP_MARKDOWN='''
 自动签到时间：每日0点10分
 自动晨午晚检时间：每日12点10分、18点10分

--- a/include/function.py
+++ b/include/function.py
@@ -2,6 +2,8 @@ import re
 from typing import Dict, Optional
 import logging
 import requests
+import datetime
+from pytz import timezone as pytz_timezone
 import logging
 import json
 from .config import *
@@ -113,3 +115,7 @@ def build_xisu_ncov_checkin_post_data(ncov_report_page_html, xisu_nconv_checkin_
     filled_form['geo_api_info'] = ncov_report_post_data['geo_api_info']
 
     return filled_form
+
+def display_time_formatted():
+    # Return human-readable date with current display timezone, regardless of the host's timezone settings
+    return datetime.datetime.now(tz=pytz_timezone(DISPLAY_TIMEZONE)).strftime('%Y-%m-%d %H:%M:%S.%f')

--- a/main.py
+++ b/main.py
@@ -347,12 +347,12 @@ def checkin_all_retry():
         ret_msg = ''
         try:
             ret = user.ncov_checkin()[:100]
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试签到成功！\n服务器返回：`{ret}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试签到成功！\n服务器返回：`{ret}`\n{display_time_formatted()}"
         except requests.exceptions.Timeout as e:
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试签到失败，服务器错误，请尝试手动签到！\nhttps://app.bupt.edu.cn/ncov/wap/default/index\n`{e}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试签到失败，服务器错误，请尝试手动签到！\nhttps://app.bupt.edu.cn/ncov/wap/default/index\n`{e}`\n{display_time_formatted()}"
             traceback.print_exc()
         except Exception as e:
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试签到异常！\n服务器返回：`{e}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试签到异常！\n服务器返回：`{e}`\n{display_time_formatted()}"
             traceback.print_exc()
         logger.info(ret_msg)
         try:
@@ -371,12 +371,12 @@ def checkin_all():
         ret_msg = ''
         try:
             ret = user.ncov_checkin()[:100]
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动签到成功！\n服务器返回：`{ret}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动签到成功！\n服务器返回：`{ret}`\n{display_time_formatted()}"
         except requests.exceptions.Timeout as e:
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动签到失败，服务器错误，将重试！\n`{e}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动签到失败，服务器错误，将重试！\n`{e}`\n{display_time_formatted()}"
             traceback.print_exc()
         except Exception as e:
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动签到异常！\n服务器返回：`{e}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动签到异常！\n服务器返回：`{e}`\n{display_time_formatted()}"
             traceback.print_exc()
         logger.info(ret_msg)
         try:
@@ -396,12 +396,12 @@ def checkin_all_xisu_retry():
         ret_msg = ''
         try:
             ret = user.xisu_ncov_checkin()[:100]
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试晨午晚检成功！\n服务器返回：`{ret}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试晨午晚检成功！\n服务器返回：`{ret}`\n{display_time_formatted()}"
         except requests.exceptions.Timeout as e:
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试晨午晚检失败，服务器错误，请尝试手动签到！\n{config.XISU_REPORT_PAGE}\n`{e}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试晨午晚检失败，服务器错误，请尝试手动签到！\n{config.XISU_REPORT_PAGE}\n`{e}`\n{display_time_formatted()}"
             traceback.print_exc()
         except Exception as e:
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试晨午晚检异常！\n服务器返回：`{e}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n重试晨午晚检异常！\n服务器返回：`{e}`\n{display_time_formatted()}"
             traceback.print_exc()
         logger.info(ret_msg)
         try:
@@ -424,12 +424,12 @@ def checkin_all_xisu():
         ret_msg = ''
         try:
             ret = user.xisu_ncov_checkin()[:100]
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动晨午晚检成功！\n服务器返回：`{ret}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动晨午晚检成功！\n服务器返回：`{ret}`\n{display_time_formatted()}"
         except requests.exceptions.Timeout as e:
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动晨午晚检失败，服务器错误，将重试！\n`{e}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动晨午晚检失败，服务器错误，将重试！\n`{e}`\n{display_time_formatted()}"
             traceback.print_exc()
         except Exception as e:
-            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动晨午晚检异常！\n服务器返回：`{e}`\n{datetime.datetime.now()}"
+            ret_msg = f"用户：`{user.username or user.cookie_eaisess or '[None]'}`\n自动晨午晚检异常！\n服务器返回：`{e}`\n{display_time_formatted()}"
             traceback.print_exc()
         logger.info(ret_msg)
         try:


### PR DESCRIPTION
目前的 bot 代码中，给用户发送消息时，所显示的时间文本是与服务器时区相关的。[buptncovbot](https://t.me/buptncovbot) 架设在日本服务器上（？），因此显示的时间是日本时间，感觉非常不便。

本 PR 加入了设置显示时区的功能，并将默认值设为 `Asia/Shanghai` 以满足大部分人需要。另外，建议 [buptncovbot](https://t.me/buptncovbot) 也把默认显示时区设为 `Asia/Shanghai`。