### PR TITLE
Fix: Dependency conflict of requests and urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ APScheduler==3.6.3
 certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
+charset-normalizer==2.0.12
 cryptography==3.3.2
 decorator==4.4.1
 future==0.18.2
@@ -11,8 +12,8 @@ pycparser==2.19
 PySocks==1.7.1
 python-telegram-bot==12.4.2
 pytz==2019.3
-requests==2.23.0
+requests==2.27.1
 six==1.14.0
 tornado==6.0.3
 tzlocal==2.0.0
-urllib3==1.26.5
+urllib3==1.25.11


### PR DESCRIPTION
According to
https://github.com/HenryzhaoH/bupt-ncov-report-tgbot/pull/13

> https://github.com/advisories/GHSA-5phf-pp7p-vc2r
> > urllib3 >= 1.26.0, < 1.26.4
> > Users who are using an HTTPS proxy to issue HTTPS requests
> >  and haven't configured their own SSLContext via proxy_config.
> >  Only the default SSLContext is impacted.

https://github.com/apps/dependabot recomment to upgrade urllib3 from
1.25.8 to 1.26.5 in #13

However, according to
https://github.com/psf/requests/blob/c7e0fc087ceeadb8b4c84a0953a422c474093d6d/setup.py#L47

> requires = [
>     'chardet>=3.0.2,<4',
>     'idna>=2.5,<3',
>     'urllib3>=1.21.1,<1.26,!=1.25.0,!=1.25.1',
>     'certifi>=2017.4.17'
>
> ]

requests==2.23.0 requires urllib3>=1.21.1,<1.26,!=1.25.0,!=1.25.1

Give that requests==2.27.1 work well with urllib3==1.25.11, as well as
> urllib3<1.26 is not impacted due to not supporting HTTPS requests via HTTPS proxies.
read from https://github.com/advisories/GHSA-5phf-pp7p-vc2r

In conclusion, the decision of upgrading requests requirement was made.
At the same time, downgrade urllib3 to 1.25.11.

Signed-off-by: FredericDT <frederic.dt.twh@gmail.com>